### PR TITLE
Reworked CtrlCHandler

### DIFF
--- a/cpp/include/DataStorm/CtrlCHandler.h
+++ b/cpp/include/DataStorm/CtrlCHandler.h
@@ -65,13 +65,13 @@ public:
      * @param cb The new callback.
      * @return The old callback
      */
-    CtrlCHandlerCallback setCallback(CtrlCHandlerCallback cb);
+    CtrlCHandlerCallback setCallback(CtrlCHandlerCallback cb) noexcept;
 
     /**
      * Obtain the signal callback.
      * @return The callback
      */
-    CtrlCHandlerCallback getCallback() const;
+    CtrlCHandlerCallback getCallback() const noexcept;
 };
 }
 

--- a/cpp/src/DataStorm/CtrlCHandler.cpp
+++ b/cpp/src/DataStorm/CtrlCHandler.cpp
@@ -28,7 +28,7 @@ bool _signalsMasked = false;
 }
 
 CtrlCHandlerCallback
-CtrlCHandler::setCallback(CtrlCHandlerCallback callback)
+CtrlCHandler::setCallback(CtrlCHandlerCallback callback) noexcept
 {
     std::lock_guard<std::mutex> lg(_mutex);
     CtrlCHandlerCallback oldCallback = _callback;
@@ -37,7 +37,7 @@ CtrlCHandler::setCallback(CtrlCHandlerCallback callback)
 }
 
 CtrlCHandlerCallback
-CtrlCHandler::getCallback() const
+CtrlCHandler::getCallback() const noexcept
 {
     std::lock_guard<std::mutex> lg(_mutex);
     return _callback;


### PR DESCRIPTION
Reworked CtrlCHandler's implementation to use C++11 library features like std::mutex.

Also changed the semantics on Windows: maskSignals now adds the handler routine, and CtrlCHandler just sets / unsets the callback used by this routine. This way, on all platforms signals are ignored after CtrCHandler is destroyed.