### PR TITLE
Fix Windows build failures & update Ice msbuild builder

### DIFF
--- a/cpp/msbuild/datastorm.cpp.props
+++ b/cpp/msbuild/datastorm.cpp.props
@@ -7,7 +7,7 @@
 
     <!-- Define some common properties -->
     <PropertyGroup>
-        <DataStormSoVersion>0</DataStormSoVersion>
+        <DataStormSoVersion>11</DataStormSoVersion>
         <DataStormSrcRootDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..'))</DataStormSrcRootDir>
         <IntDir>$(Platform)\$(Configuration)\</IntDir>
         <LinkIncremental>false</LinkIncremental>

--- a/cpp/src/DataStorm/msbuild/datastorm/datastorm.vcxproj
+++ b/cpp/src/DataStorm/msbuild/datastorm/datastorm.vcxproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
-  <Import Project="..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -47,7 +47,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\datastorm.cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -269,8 +269,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
     <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props'))" />
     <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
   </Target>

--- a/cpp/src/DataStorm/msbuild/datastorm/packages.config
+++ b/cpp/src/DataStorm/msbuild/datastorm/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/cpp/test/DataStorm/api/msbuild/writer/packages.config
+++ b/cpp/test/DataStorm/api/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/cpp/test/DataStorm/api/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/api/msbuild/writer/writer.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
-  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -107,7 +107,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\datastorm.test.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" />
   </ImportGroup>
@@ -161,7 +161,7 @@
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
 </Project>

--- a/cpp/test/DataStorm/config/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/config/msbuild/writer/writer.vcxproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
-  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props')" />
+  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
+  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/cpp/test/DataStorm/events/msbuild/reader/packages.config
+++ b/cpp/test/DataStorm/events/msbuild/reader/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/cpp/test/DataStorm/events/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/events/msbuild/reader/reader.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
-  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -107,7 +107,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\datastorm.test.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" />
   </ImportGroup>
@@ -161,7 +161,7 @@
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
 </Project>

--- a/cpp/test/DataStorm/events/msbuild/writer/packages.config
+++ b/cpp/test/DataStorm/events/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/cpp/test/DataStorm/events/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/events/msbuild/writer/writer.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
-  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -107,7 +107,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\datastorm.test.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" />
   </ImportGroup>
@@ -161,7 +161,7 @@
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
 </Project>

--- a/cpp/test/DataStorm/partial/msbuild/reader/packages.config
+++ b/cpp/test/DataStorm/partial/msbuild/reader/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/cpp/test/DataStorm/partial/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/partial/msbuild/reader/reader.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
-  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -107,7 +107,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\datastorm.test.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" />
   </ImportGroup>
@@ -161,7 +161,7 @@
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
 </Project>

--- a/cpp/test/DataStorm/partial/msbuild/writer/packages.config
+++ b/cpp/test/DataStorm/partial/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/cpp/test/DataStorm/partial/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/partial/msbuild/writer/writer.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
-  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -107,7 +107,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\datastorm.test.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" />
   </ImportGroup>
@@ -161,7 +161,7 @@
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
 </Project>

--- a/cpp/test/DataStorm/types/msbuild/reader/packages.config
+++ b/cpp/test/DataStorm/types/msbuild/reader/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/cpp/test/DataStorm/types/msbuild/reader/reader.vcxproj
+++ b/cpp/test/DataStorm/types/msbuild/reader/reader.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
-  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -107,7 +107,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\datastorm.test.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" />
   </ImportGroup>
@@ -161,7 +161,7 @@
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
 </Project>

--- a/cpp/test/DataStorm/types/msbuild/writer/packages.config
+++ b/cpp/test/DataStorm/types/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/cpp/test/DataStorm/types/msbuild/writer/writer.vcxproj
+++ b/cpp/test/DataStorm/types/msbuild/writer/writer.vcxproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props')" />
-  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -107,7 +107,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\msbuild\datastorm.test.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+    <Import Project="..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
     <Import Project="..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets')" />
   </ImportGroup>
@@ -161,7 +161,7 @@
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
 </Project>

--- a/demos/cpp/clock/msbuild/reader/packages.config
+++ b/demos/cpp/clock/msbuild/reader/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/clock/msbuild/reader/reader.vcxproj
+++ b/demos/cpp/clock/msbuild/reader/reader.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -78,10 +78,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/clock/msbuild/writer/packages.config
+++ b/demos/cpp/clock/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/clock/msbuild/writer/writer.vcxproj
+++ b/demos/cpp/clock/msbuild/writer/writer.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -78,10 +78,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/keyFilter/msbuild/reader/packages.config
+++ b/demos/cpp/keyFilter/msbuild/reader/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/keyFilter/msbuild/reader/reader.vcxproj
+++ b/demos/cpp/keyFilter/msbuild/reader/reader.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -74,10 +74,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/keyFilter/msbuild/writer/packages.config
+++ b/demos/cpp/keyFilter/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/keyFilter/msbuild/writer/writer.vcxproj
+++ b/demos/cpp/keyFilter/msbuild/writer/writer.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -74,10 +74,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/minimal/msbuild/reader/packages.config
+++ b/demos/cpp/minimal/msbuild/reader/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/minimal/msbuild/reader/reader.vcxproj
+++ b/demos/cpp/minimal/msbuild/reader/reader.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -74,10 +74,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/minimal/msbuild/writer/packages.config
+++ b/demos/cpp/minimal/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/minimal/msbuild/writer/writer.vcxproj
+++ b/demos/cpp/minimal/msbuild/writer/writer.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -74,10 +74,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/node/msbuild/reader/packages.config
+++ b/demos/cpp/node/msbuild/reader/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/node/msbuild/reader/reader.vcxproj
+++ b/demos/cpp/node/msbuild/reader/reader.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -78,10 +78,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/node/msbuild/writer/packages.config
+++ b/demos/cpp/node/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/node/msbuild/writer/writer.vcxproj
+++ b/demos/cpp/node/msbuild/writer/writer.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -78,10 +78,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/sampleFilter/msbuild/reader/packages.config
+++ b/demos/cpp/sampleFilter/msbuild/reader/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/sampleFilter/msbuild/reader/reader.vcxproj
+++ b/demos/cpp/sampleFilter/msbuild/reader/reader.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -74,10 +74,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/sampleFilter/msbuild/writer/packages.config
+++ b/demos/cpp/sampleFilter/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/sampleFilter/msbuild/writer/writer.vcxproj
+++ b/demos/cpp/sampleFilter/msbuild/writer/writer.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -74,10 +74,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/stock/msbuild/reader/packages.config
+++ b/demos/cpp/stock/msbuild/reader/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/stock/msbuild/reader/reader.vcxproj
+++ b/demos/cpp/stock/msbuild/reader/reader.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -127,10 +127,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>

--- a/demos/cpp/stock/msbuild/writer/packages.config
+++ b/demos/cpp/stock/msbuild/writer/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="zeroc.datastorm.v143" version="1.1.0" targetFramework="native" />
   <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
-  <package id="zeroc.icebuilder.msbuild" version="5.0.4" targetFramework="native" />
+  <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/stock/msbuild/writer/writer.vcxproj
+++ b/demos/cpp/stock/msbuild/writer/writer.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
    <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" />
    <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -127,10 +127,10 @@
     <Error Condition="!Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
     <Error Condition="!Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.props'))" />
-    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
   </Target>
   <Import Project="..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
   <Import Project="..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_HOME)' == ''" />
-  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.4\build\zeroc.icebuilder.msbuild.targets')" />
+  <Import Project="..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
 </Project>


### PR DESCRIPTION
This PR fixes a Windows build failure due to bogus `DataStormSoVersion` and updates the Ice builder msbuild package used to build datastorm