### PR TITLE
Update Ice and DataStorm versions

### DIFF
--- a/config/Make.rules
+++ b/config/Make.rules
@@ -59,7 +59,7 @@ include $(top_srcdir)/config/Make.rules.$(os)
 include $(top_srcdir)/config/Make.project.rules
 include $(top_srcdir)/config/Make.tests.rules
 
-version                 = 1.1.0
+version                 = 1.1.1
 soversion               = 11
 
 #

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -179,7 +179,7 @@ You can create a NuGet package with the following command:
 msbuild msbuild\datastorm.proj /t:NuGetPack /p:BuildAllConfigurations=yes
 ```
 
-This creates `msbuild\zeroc.datastorm.v143\zeroc.datastorm.v143.1.1.0.nupkg`.
+This creates `msbuild\zeroc.datastorm.v143\zeroc.datastorm.v143.1.1.1.nupkg`.
 
 ## Cleaning the source build on macOS or Linux
 
@@ -214,5 +214,5 @@ If everything worked out, you should see lots of `ok` messages. In case of a
 failure, the tests abort with `failed`.
 
 [1]: https://zeroc.com/downloads/datastorm
-[2]: https://doc.zeroc.com/datastorm/latest/release-notes/supported-platforms-for-datastorm-1.1.0
+[2]: https://doc.zeroc.com/datastorm/latest/release-notes/supported-platforms-for-datastorm-1.1.1
 [3]: https://doc.zeroc.com/ice/3.7/release-notes/using-the-linux-binary-distributions#id-.UsingtheLinuxBinaryDistributionsv3.7-InstallingtheLinuxDistributions

--- a/cpp/include/DataStorm/Config.h
+++ b/cpp/include/DataStorm/Config.h
@@ -4,8 +4,8 @@
 //
 #pragma once
 
-#define DATASTORM_VERSION 1,1,0,0
-#define DATASTORM_STRING_VERSION "1.1.0"
+#define DATASTORM_VERSION 1,1,1,0
+#define DATASTORM_STRING_VERSION "1.1.1"
 #define DATASTORM_SO_VERSION "11"
 
 #if defined(_DEBUG)

--- a/cpp/msbuild/datastorm.proj
+++ b/cpp/msbuild/datastorm.proj
@@ -13,7 +13,7 @@
       <SymbolServer Condition="'$(SymbolServer)' == ''">$(TEMP)\SymbolCache*https://symbols.zeroc.com</SymbolServer>
       <NugetExe>$(MSBuildThisFileDirectory)NuGet.exe</NugetExe>
       <NugetURL>https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe</NugetURL>
-      <DataStormJSONVersion>1.1.0</DataStormJSONVersion>
+      <DataStormJSONVersion>1.1.1</DataStormJSONVersion>
     </PropertyGroup>
 
     <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/cpp/msbuild/zeroc.datastorm.v143.nuspec
+++ b/cpp/msbuild/zeroc.datastorm.v143.nuspec
@@ -13,7 +13,7 @@
     <releaseNotes>https://doc.zeroc.com/datastorm/latest/release-notes</releaseNotes>
     <tags>datastorm ice native dds v143 zeroc</tags>
     <dependencies>
-      <dependency id="zeroc.ice.v143" version="[3.7.8]"/>
+      <dependency id="zeroc.ice.v143" version="[3.7.9, 3.8.0)"/>
     </dependencies>
   </metadata>
 </package>

--- a/cpp/src/DataStorm/msbuild/datastorm/datastorm.vcxproj
+++ b/cpp/src/DataStorm/msbuild/datastorm/datastorm.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
+  <Import Project="..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props')" />
   <Import Project="..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -48,7 +48,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\msbuild\datastorm.cpp.props" />
   <ImportGroup Label="ExtensionSettings">
     <Import Project="..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" />
-    <Import Project="..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
+    <Import Project="..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets')" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -271,7 +271,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.props'))" />
     <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.icebuilder.msbuild.5.0.9\build\zeroc.icebuilder.msbuild.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props'))" />
-    <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props'))" />
+    <Error Condition="!Exists('..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets'))" />
   </Target>
 </Project>

--- a/cpp/src/DataStorm/msbuild/datastorm/packages.config
+++ b/cpp/src/DataStorm/msbuild/datastorm/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
+  <package id="zeroc.ice.v143" version="3.7.9" targetFramework="native" />
   <package id="zeroc.icebuilder.msbuild" version="5.0.9" targetFramework="native" />
 </packages>

--- a/cpp/src/node/msbuild/node.vcxproj
+++ b/cpp/src/node/msbuild/node.vcxproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" />
-  <Import Project="..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
+  <Import Project="..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props')" />
+  <Import Project="..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.1\build\native\zeroc.datastorm.v143.props" Condition="Exists('..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.1\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -53,8 +53,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\msbuild\datastorm.cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" />
-    <Import Project="..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" />
+    <Import Project="..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.1\build\native\zeroc.datastorm.v143.targets" Condition="Exists('..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.1\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" />
+    <Import Project="..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets" Condition="Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets')" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -107,11 +107,11 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props'))" />
-    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.props'))" />
-    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.0\build\native\zeroc.datastorm.v143.targets'))" />
-    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.props'))" />
-    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.ice.v143.3.7.8\build\native\zeroc.ice.v143.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.1\build\native\zeroc.datastorm.v143.props') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.1\build\native\zeroc.datastorm.v143.props'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.1\build\native\zeroc.datastorm.v143.targets') and '$(DATASTORM_BIN_DIST)' == 'all'" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.datastorm.v143.1.1.1\build\native\zeroc.datastorm.v143.targets'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.props'))" />
+    <Error Condition="!Exists('..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\msbuild\packages\zeroc.ice.v143.3.7.9\build\native\zeroc.ice.v143.targets'))" />
   </Target>
 </Project>

--- a/cpp/src/node/msbuild/packages.config
+++ b/cpp/src/node/msbuild/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zeroc.ice.v143" version="3.7.8" targetFramework="native" />
+  <package id="zeroc.ice.v143" version="3.7.9" targetFramework="native" />
 </packages>

--- a/demos/cpp/README.md
+++ b/demos/cpp/README.md
@@ -81,13 +81,13 @@ the demos.
 If you are building Debug, add the Debug `bin` directories with a command similar
 to:
 ```
-set PATH=%USERPROFILE%\datastorm\demos\cpp\packages\zeroc.datastorm.v143.1.1.0\build\native\bin\x64\Debug;%USERPROFILE%\datastorm\demos\cpp\packages\zeroc.ice.v143.3.7.8\build\native\bin\x64\Debug;%PATH%
+set PATH=%USERPROFILE%\datastorm\demos\cpp\packages\zeroc.datastorm.v143.1.1.1\build\native\bin\x64\Debug;%USERPROFILE%\datastorm\demos\cpp\packages\zeroc.ice.v143.3.7.9\build\native\bin\x64\Debug;%PATH%
 ```
 
 If you are building Release, add the Release `bin` directories with a command
 similar to:
 ```
-set PATH=%USERPROFILE%\datastorm\demos\cpp\packages\zeroc.datastorm.v143.1.1.0\build\native\bin\x64\Release;%USERPROFILE%\datastorm\demos\cpp\packages\zeroc.ice.v143.3.7.8\build\native\bin\x64\Release;%PATH%
+set PATH=%USERPROFILE%\datastorm\demos\cpp\packages\zeroc.datastorm.v143.1.1.1\build\native\bin\x64\Release;%USERPROFILE%\datastorm\demos\cpp\packages\zeroc.ice.v143.3.7.9\build\native\bin\x64\Release;%PATH%
 ```
 
 Then refer to the README.md file in each demo directory for usage instructions.

--- a/demos/cpp/make/Make.rules
+++ b/demos/cpp/make/Make.rules
@@ -8,13 +8,13 @@
 # Define ICE_HOME if Ice is not installed in /usr (Linux) or
 # /usr/local (macOS)
 #
-#ICE_HOME               ?= /opt/Ice-3.7.8
+#ICE_HOME               ?= /opt/Ice-3.7.9
 
 #
 # Define DATASTORM_HOME if DataStorm is not installed in /usr (Linux) or
 # /usr/local (macOS)
 #
-#DATASTORM_HOME         ?= /opt/DataStorm-1.1.0
+#DATASTORM_HOME         ?= /opt/DataStorm-1.1.1
 
 #
 # Define OPTIMIZE as yes if you want to build with optimization.

--- a/demos/cpp/msbuild/datastorm.proj
+++ b/demos/cpp/msbuild/datastorm.proj
@@ -9,7 +9,7 @@
     <PropertyGroup>
       <NugetExe>$(MSBuildThisFileDirectory)NuGet.exe</NugetExe>
       <NugetURL>https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe</NugetURL>
-      <DataStormJSONVersion>1.1.0</DataStormJSONVersion>
+      <DataStormJSONVersion>1.1.1</DataStormJSONVersion>
     </PropertyGroup>
 
     <!-- Download nuget.exe if not present -->
@@ -29,7 +29,7 @@
     <Target Name="DownloadSymbols" DependsOnTargets="NuGetRestore">
         <MakeDir Directories="$(TEMP)\SymbolCache" />
         <Exec IgnoreExitCode="True"
-              Command="symchk /r $(MSBuildThisFileDirectory)..\packages\zeroc.datastorm.$(DefaultPlatformToolset).1.1.0\build\native\bin\$(Platform)\$(Configuration)\* /s $(SymbolServer)">
+              Command="symchk /r $(MSBuildThisFileDirectory)..\packages\zeroc.datastorm.$(DefaultPlatformToolset).1.1.1\build\native\bin\$(Platform)\$(Configuration)\* /s $(SymbolServer)">
               <Output TaskParameter="ExitCode" PropertyName="ErrorCode"/>
         </Exec>
         <Warning  Text="PDBs download failed, stack traces might be missing or incomplete" Condition="'$(ErrorCode)' != '0'" />


### PR DESCRIPTION
This PR includes the following updates:

- DataStorm version is now 1.1.1.
- Windows projects have been upgraded to use Ice 3.7.9.
- DataStorm NuGet package uses a version range for the Ice dependency, to allow any 3.7 patch release greater or equal than 3.7.9.